### PR TITLE
Improve bash completion

### DIFF
--- a/completion.bash
+++ b/completion.bash
@@ -1,8 +1,8 @@
 _project_rb_complete() {
   COMPREPLY=()
   local word="${COMP_WORDS[COMP_CWORD]}"
-  local completions="$(./project.rb --cmplt "$COMP_CWORD" "${COMP_WORDS[@]}")"
+  local completions="$($1 --cmplt "$COMP_CWORD" "${COMP_WORDS[@]}")"
   COMPREPLY=( $(compgen -W "$completions" -- "$word") )
 }
 
-complete -f -F _project_rb_complete ./project.rb
+complete -F _project_rb_complete ./project.rb


### PR DESCRIPTION
Does two things
- remove `-f` parameter so only `project.rb` commands are shown in auto complete. Useful if you just want to see a list of what's available. I don't think there's any command which takes `./project [filename]`

- use the bash arg `$1` over `./project.rb`. This allows the completion to be run from any directory. Ex. `./api/project.rb`